### PR TITLE
Dataset loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.sh

--- a/backend/cmd/worldle/main.go
+++ b/backend/cmd/worldle/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/MaarceloLuiz/worldle-replica/pkg/geography/silhouettes"
+)
+
+func main() {
+	response, err := silhouettes.FetchSilhouette()
+	if err != nil {
+		fmt.Println("Error fetching silhouette:", err)
+	}
+
+	fmt.Println(string(response))
+}

--- a/backend/cmd/worldle/main.go
+++ b/backend/cmd/worldle/main.go
@@ -2,15 +2,21 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/MaarceloLuiz/worldle-replica/pkg/geography/silhouettes"
 )
 
 func main() {
-	response, err := silhouettes.FetchSilhouette()
+	img, err := silhouettes.FetchSilhouette()
 	if err != nil {
 		fmt.Println("Error fetching silhouette:", err)
+		return
 	}
 
-	fmt.Println(string(response))
+	if err := os.WriteFile("output.png", img, 0644); err != nil {
+		fmt.Println("could not write file:", err)
+		return
+	}
+	fmt.Println("OK — wrote out.png (size:", len(img), "bytes)")
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,7 @@
+module github.com/MaarceloLuiz/worldle-replica
+
+go 1.24.2
+
+require github.com/sirupsen/logrus v1.9.3
+
+require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/pkg/geography/silhouettes/loader.go
+++ b/backend/pkg/geography/silhouettes/loader.go
@@ -1,0 +1,120 @@
+package silhouettes
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/MaarceloLuiz/worldle-replica/pkg/github"
+	"github.com/sirupsen/logrus"
+)
+
+type SilhouetteResponse struct {
+	URL string `json:"url"`
+}
+
+func FetchSilhouette() ([]byte, error) {
+	gitConfig, err := github.LoadGitConfig()
+	if err != nil {
+		logrus.Error("Error loading GitHub configuration")
+		return nil, err
+	}
+
+	country, err := getRandomCountry()
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/silhouettes/%s.png",
+		gitConfig.Owner, gitConfig.Repo, gitConfig.Branch, country)
+
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		logrus.Error("Error creating request to GitHub API")
+		return nil, err
+	}
+
+	request.Header.Set("Authorization", "Bearer "+gitConfig.Token)
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		logrus.Error("Failed to make request to GitHub API: Authorization issue or network error")
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		logrus.Error("Failed to fetch silhouette from GitHub API: ", response.Status)
+		return nil, fmt.Errorf("failed to fetch silhouette from GitHub API: %s", response.Status)
+	}
+
+	silhouetteResponse := SilhouetteResponse{URL: url}
+	jsonResponse, err := json.Marshal(silhouetteResponse)
+	if err != nil {
+		logrus.Error("Failed to marshal silhouette response to JSON")
+		return nil, err
+	}
+
+	return jsonResponse, nil
+}
+
+func getRandomCountry() (string, error) {
+	gitConfig, err := github.LoadGitConfig()
+	if err != nil {
+		logrus.Error("Error loading GitHub configuration")
+		return "", err
+	}
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/silhouettes?ref=%s",
+		gitConfig.Owner, gitConfig.Repo, gitConfig.Branch)
+
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		logrus.Error("Error creating request to GitHub API")
+		return "", err
+	}
+
+	request.Header.Set("Authorization", "Bearer "+gitConfig.Token)
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		logrus.Error("Failed to make request to GitHub API: Authorization issue or network error")
+		return "", err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		logrus.Error("Failed to fetch silhouettes from GitHub API: ", response.Status)
+		return "", fmt.Errorf("failed to fetch silhouettes from GitHub API: %s", response.Status)
+	}
+
+	var files []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&files); err != nil {
+		logrus.Error("Failed to decode response from GitHub API")
+		return "", err
+	}
+
+	var countries []string
+	for _, file := range files {
+		if strings.HasSuffix(file.Name, ".png") {
+			countries = append(countries, strings.TrimSuffix(file.Name, ".png"))
+		}
+	}
+
+	if len(countries) == 0 {
+		logrus.Error("No silhouette files found in the repository")
+		return "", fmt.Errorf("no silhouette files found in the repository")
+	}
+
+	seed := time.Now().UnixNano() // to avoid seeding the same number every time
+	random := rand.New(rand.NewSource(seed))
+
+	randomIndex := random.Intn(len(countries))
+	randomCountry := countries[randomIndex]
+
+	return randomCountry, nil
+}

--- a/backend/pkg/github/github.go
+++ b/backend/pkg/github/github.go
@@ -1,0 +1,28 @@
+package github
+
+import (
+	"fmt"
+	"os"
+)
+
+type GitConfig struct {
+	Token  string `env:"GITHUB_TOKEN"`
+	Repo   string `env:"GITHUB_REPO"`
+	Owner  string `env:"GITHUB_OWNER"`
+	Branch string `env:"GITHUB_BRANCH"`
+}
+
+func LoadGitConfig() (*GitConfig, error) {
+	gitConfig := &GitConfig{
+		Token:  os.Getenv("GITHUB_TOKEN"),
+		Repo:   os.Getenv("GITHUB_REPO"),
+		Owner:  os.Getenv("GITHUB_OWNER"),
+		Branch: os.Getenv("GITHUB_BRANCH"),
+	}
+
+	if gitConfig.Token == "" || gitConfig.Repo == "" || gitConfig.Owner == "" || gitConfig.Branch == "" {
+		return nil, fmt.Errorf("missing required GitHub configuration")
+	}
+
+	return gitConfig, nil
+}


### PR DESCRIPTION
- github.LoadGitConfig() → env vars are now the single source (GITHUB_TOKEN/OWNER/REPO/BRANCH)
- pkg/silhouettes/loader.go → now fetches PNGs through the GitHub REST API 
- cmd/worldle/main.go → demo code that calls FetchSilhouette() and writes out 'output.png' → (temporary smoke test; will be removed soon)

Issue: https://github.com/MaarceloLuiz/worldle-replica/issues/8