### PR TITLE
POST /api/guess

### DIFF
--- a/backend/cmd/worldle/main.go
+++ b/backend/cmd/worldle/main.go
@@ -11,6 +11,7 @@ func main() {
 	http.HandleFunc("/api/newgame", api.NewGameHandler)
 	http.HandleFunc("/api/silhouette", api.SilhouetteHandler)
 	http.HandleFunc("/api/territories", api.AllTerritoriesHandler)
+	http.HandleFunc("/api/guess", api.GuessHandler)
 
 	logrus.Info("Starting server on :8080")
 	logrus.Fatal(http.ListenAndServe(":8080", nil))

--- a/backend/pkg/api/handler.go
+++ b/backend/pkg/api/handler.go
@@ -51,6 +51,18 @@ func AllTerritoriesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func GuessHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message": "Use POST with a JSON payload to make a guess."}`))
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "Invalid request method. Use POST.", http.StatusMethodNotAllowed)
+		return
+	}
+
 	var guessCountry struct {
 		Guess string `json:"guess"`
 	}
@@ -68,15 +80,9 @@ func GuessHandler(w http.ResponseWriter, r *http.Request) {
 	// Case-insensitive comparison of guess and current country.
 	isCorrect := strings.EqualFold(guessCountry.Guess, answerCountry)
 
-	distance, err := geocalc.GetDistance(guessCountry.Guess, answerCountry)
+	distance, direction, err := geocalc.GetDistanceAndDirection(guessCountry.Guess, answerCountry)
 	if err != nil {
 		http.Error(w, "Failed to calculate distance", http.StatusInternalServerError)
-		return
-	}
-
-	direction, err := geocalc.GetDirection(guessCountry.Guess, answerCountry)
-	if err != nil {
-		http.Error(w, "Failed to calculate direction", http.StatusInternalServerError)
 		return
 	}
 

--- a/backend/pkg/api/handler.go
+++ b/backend/pkg/api/handler.go
@@ -3,9 +3,11 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/MaarceloLuiz/worldle-replica/pkg/game"
-	geography "github.com/MaarceloLuiz/worldle-replica/pkg/geography/territories"
+	"github.com/MaarceloLuiz/worldle-replica/pkg/geography/geocalc"
+	terr "github.com/MaarceloLuiz/worldle-replica/pkg/geography/territories"
 )
 
 func NewGameHandler(w http.ResponseWriter, r *http.Request) {
@@ -32,7 +34,7 @@ func SilhouetteHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func AllTerritoriesHandler(w http.ResponseWriter, r *http.Request) {
-	territories, err := geography.GetFormattedTerritoryNames()
+	territories, err := terr.GetFormattedTerritoryNames()
 	if err != nil {
 		http.Error(w, "Failed to fetch territories", http.StatusInternalServerError)
 		return
@@ -46,4 +48,44 @@ func AllTerritoriesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Write(jsonData)
+}
+
+func GuessHandler(w http.ResponseWriter, r *http.Request) {
+	var guessCountry struct {
+		Guess string `json:"guess"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&guessCountry); err != nil {
+		http.Error(w, "Invalid request payload", http.StatusBadRequest)
+		return
+	}
+
+	answerCountry := game.State.Country
+	if answerCountry == "" {
+		http.Error(w, "Game not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	// Case-insensitive comparison of guess and current country.
+	isCorrect := strings.EqualFold(guessCountry.Guess, answerCountry)
+
+	distance, err := geocalc.GetDistance(guessCountry.Guess, answerCountry)
+	if err != nil {
+		http.Error(w, "Failed to calculate distance", http.StatusInternalServerError)
+		return
+	}
+
+	direction, err := geocalc.GetDirection(guessCountry.Guess, answerCountry)
+	if err != nil {
+		http.Error(w, "Failed to calculate direction", http.StatusInternalServerError)
+		return
+	}
+
+	response := map[string]interface{}{
+		"isCorrect": isCorrect,
+		"distance":  distance,
+		"direction": direction,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
 }

--- a/backend/pkg/geography/geocalc/bearing.go
+++ b/backend/pkg/geography/geocalc/bearing.go
@@ -20,14 +20,22 @@ func getCompass(guessLat, guessLng, answerLat, answerLng float64) string {
 
 func degreesToCompass(degrees float64) string {
 	ranges := map[string][2]float64{
-		"N":  {337.5, 22.5},
-		"NE": {22.5, 67.5},
-		"E":  {67.5, 112.5},
-		"SE": {112.5, 157.5},
-		"S":  {157.5, 202.5},
-		"SW": {202.5, 247.5},
-		"W":  {247.5, 292.5},
-		"NW": {292.5, 337.5},
+		"N":   {354.375, 5.625}, // Narrow range for North
+		"NNE": {5.625, 28.125},
+		"NE":  {28.125, 61.875},
+		"ENE": {61.875, 84.375},
+		"E":   {84.375, 95.625}, // Narrow range for East
+		"ESE": {95.625, 118.125},
+		"SE":  {118.125, 151.875},
+		"SSE": {151.875, 174.375},
+		"S":   {174.375, 185.625}, // Narrow range for South
+		"SSW": {185.625, 208.125},
+		"SW":  {208.125, 241.875},
+		"WSW": {241.875, 264.375},
+		"W":   {264.375, 275.625}, // Narrow range for West
+		"WNW": {275.625, 298.125},
+		"NW":  {298.125, 331.875},
+		"NNW": {331.875, 354.375},
 	}
 
 	// special case for North since it wraps around 360
@@ -57,8 +65,14 @@ func radiansToDegrees(bearing float64) float64 {
 
 // θ = atan2( sin Δλ ⋅ cos φ2 , cos φ1 ⋅ sin φ2 − sin φ1 ⋅ cos φ2 ⋅ cos Δλ )
 func initialBearing(guessLat, guessLng, answerLat, answerLng float64) float64 {
-	y := math.Sin(answerLng-guessLng) * math.Cos(answerLat)
-	x := math.Cos(guessLat)*math.Sin(answerLat) - math.Sin(guessLat)*math.Cos(answerLat)*math.Cos(answerLng-guessLng)
+	guessLatRad := guessLat * (math.Pi / 180)
+	guessLngRad := guessLng * (math.Pi / 180)
+	answerLatRad := answerLat * (math.Pi / 180)
+	answerLngRad := answerLng * (math.Pi / 180)
+	deltaLng := answerLngRad - guessLngRad
+
+	y := math.Sin(deltaLng) * math.Cos(answerLatRad)
+	x := math.Cos(guessLatRad)*math.Sin(answerLatRad) - math.Sin(guessLatRad)*math.Cos(answerLatRad)*math.Cos(answerLngRad-guessLngRad)
 	bearing := math.Atan2(y, x)
 
 	return bearing

--- a/backend/pkg/geography/geocalc/bearing.go
+++ b/backend/pkg/geography/geocalc/bearing.go
@@ -1,0 +1,65 @@
+package geocalc
+
+import (
+	"math"
+
+	"github.com/sirupsen/logrus"
+)
+
+func getCompass(guessLat, guessLng, answerLat, answerLng float64) string {
+	bearing := initialBearing(guessLat, guessLng, answerLat, answerLng)
+	degrees := radiansToDegrees(bearing)
+	normalizedDegrees := normalizeDegrees(degrees)
+	compass := degreesToCompass(normalizedDegrees)
+	if compass == "" {
+		logrus.Fatalf("Invalid compass direction for degrees: %f", normalizedDegrees)
+	}
+
+	return compass
+}
+
+func degreesToCompass(degrees float64) string {
+	ranges := map[string][2]float64{
+		"N":  {337.5, 22.5},
+		"NE": {22.5, 67.5},
+		"E":  {67.5, 112.5},
+		"SE": {112.5, 157.5},
+		"S":  {157.5, 202.5},
+		"SW": {202.5, 247.5},
+		"W":  {247.5, 292.5},
+		"NW": {292.5, 337.5},
+	}
+
+	// special case for North since it wraps around 360
+	if degrees > 337.5 || degrees <= 22.5 {
+		return "N"
+	}
+
+	for direction, bounds := range ranges {
+		if bounds[0] < degrees && degrees <= bounds[1] {
+			return direction
+		}
+	}
+
+	return "" // should never reach here if the input is valid
+}
+
+// When calculate the initial bearing using the atan2 function, the result (after converting to degrees)
+// can be any value between -180° and +180°. However, compass bearings are always expressed as 0° to 360°.
+// normalizeDegrees adjusts an angle to ensure it falls within the range of 0° to 360°.
+func normalizeDegrees(degrees float64) float64 {
+	return math.Mod(degrees+360, 360)
+}
+
+func radiansToDegrees(bearing float64) float64 {
+	return bearing * (180.0 / math.Pi)
+}
+
+// θ = atan2( sin Δλ ⋅ cos φ2 , cos φ1 ⋅ sin φ2 − sin φ1 ⋅ cos φ2 ⋅ cos Δλ )
+func initialBearing(guessLat, guessLng, answerLat, answerLng float64) float64 {
+	y := math.Sin(answerLng-guessLng) * math.Cos(answerLat)
+	x := math.Cos(guessLat)*math.Sin(answerLat) - math.Sin(guessLat)*math.Cos(answerLat)*math.Cos(answerLng-guessLng)
+	bearing := math.Atan2(y, x)
+
+	return bearing
+}

--- a/backend/pkg/geography/geocalc/haversine.go
+++ b/backend/pkg/geography/geocalc/haversine.go
@@ -1,0 +1,19 @@
+package geocalc
+
+import "math"
+
+//a = sin²(Δφ/2) + cos φ1 ⋅ cos φ2 ⋅ sin²(Δλ/2)
+//c = 2 ⋅ atan2( √a, √(1−a) )
+//d = R ⋅ c
+func haversine(guessLat, guessLng, answerLat, answerLng float64) (float64, error) {
+	R := 6371e3 //radius of the Earth in meters
+	guessLatRad := guessLat * (math.Pi / 180)
+	answerLatRad := answerLat * (math.Pi / 180)
+	deltaLat := (answerLat - guessLat) * (math.Pi / 180)
+	deltaLng := (answerLng - guessLng) * (math.Pi / 180)
+	a := math.Pow(math.Sin(deltaLat/2), 2) + math.Cos(guessLatRad)*math.Cos(answerLatRad)*math.Pow(math.Sin(deltaLng/2), 2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	d := R * c //distance in meters
+
+	return d, nil
+}

--- a/backend/pkg/geography/geocalc/haversine.go
+++ b/backend/pkg/geography/geocalc/haversine.go
@@ -6,11 +6,13 @@ import "math"
 //c = 2 ⋅ atan2( √a, √(1−a) )
 //d = R ⋅ c
 func haversine(guessLat, guessLng, answerLat, answerLng float64) (float64, error) {
-	R := 6371e3 //radius of the Earth in meters
+	const R = 6371e3 //radius of the Earth in meters
+
 	guessLatRad := guessLat * (math.Pi / 180)
 	answerLatRad := answerLat * (math.Pi / 180)
 	deltaLat := (answerLat - guessLat) * (math.Pi / 180)
 	deltaLng := (answerLng - guessLng) * (math.Pi / 180)
+
 	a := math.Pow(math.Sin(deltaLat/2), 2) + math.Cos(guessLatRad)*math.Cos(answerLatRad)*math.Pow(math.Sin(deltaLng/2), 2)
 	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
 	d := R * c //distance in meters

--- a/backend/pkg/geography/geocalc/mapsapi.go
+++ b/backend/pkg/geography/geocalc/mapsapi.go
@@ -1,0 +1,85 @@
+package geocalc
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+var mapsApiKey string
+
+func init() {
+	mapsApiKey := os.Getenv("MAPS_API_KEY")
+	if mapsApiKey == "" {
+		logrus.Fatal("MAPS_API_KEY environment variable is not set")
+	}
+}
+
+func distanceMatrix(guess, answer string) float64 {
+	url := fmt.Sprintf("https://maps.googleapis.com/maps/api/distancematrix/json?origins=%s&destinations=%s&key=%s",
+		guess, answer, mapsApiKey)
+
+	results, err := mapsApi(url)
+	if err != nil {
+		logrus.Fatalf("Failed to get distance matrix from Google Maps API: %v", err)
+	}
+
+	rows := results["rows"].([]interface{})[0].(map[string]interface{})
+	elements := rows["elements"].([]interface{})[0].(map[string]interface{})
+	distance := elements["distance"].(map[string]interface{})
+	value := distance["value"].(float64) //distance in meters
+
+	distanceKM := value / 1000
+	return distanceKM
+}
+
+func geocode(country string) (float64, float64) {
+	url := fmt.Sprintf("https://maps.googleapis.com/maps/api/geocode/json?address=%s&key=%s",
+		country, mapsApiKey)
+
+	results, err := mapsApi(url)
+	if err != nil {
+		logrus.Fatalf("Failed to get geocode from Google Maps API: %v", err)
+	}
+
+	result := results["results"].([]interface{})[0].(map[string]interface{})
+	geometry := result["geometry"].(map[string]interface{})
+	location := geometry["location"].(map[string]interface{})
+	lat := location["lat"].(float64)
+	lng := location["lng"].(float64)
+
+	return lat, lng
+}
+
+func mapsApi(url string) (map[string]interface{}, error) {
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		logrus.Fatal("Error creating request to Google Maps API")
+	}
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		logrus.Fatalf("Failed to get a response from Google Maps API: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		logrus.Fatalf("Failed to make request to Google Maps API: %v", err)
+	}
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		logrus.Fatalf("Failed to read response body from Google Maps API: %v", err)
+	}
+
+	var results map[string]interface{}
+	if err := json.Unmarshal(data, &results); err != nil {
+		logrus.Fatalf("Failed to unmarshal JSON response: %v", err)
+	}
+
+	return results, nil
+}

--- a/backend/pkg/geography/geocalc/mapsapi.go
+++ b/backend/pkg/geography/geocalc/mapsapi.go
@@ -13,27 +13,10 @@ import (
 var mapsApiKey string
 
 func init() {
-	mapsApiKey := os.Getenv("MAPS_API_KEY")
+	mapsApiKey = os.Getenv("MAPS_API_KEY")
 	if mapsApiKey == "" {
 		logrus.Fatal("MAPS_API_KEY environment variable is not set")
 	}
-}
-
-func distanceMatrix(guess, answer string) (float64, error) {
-	url := fmt.Sprintf("https://maps.googleapis.com/maps/api/distancematrix/json?origins=%s&destinations=%s&key=%s",
-		guess, answer, mapsApiKey)
-
-	results, err := mapsApi(url)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get distance matrix from Google Maps API: %w", err)
-	}
-
-	rows := results["rows"].([]interface{})[0].(map[string]interface{})
-	elements := rows["elements"].([]interface{})[0].(map[string]interface{})
-	distance := elements["distance"].(map[string]interface{})
-	value := distance["value"].(float64) //distance in meters
-
-	return value, nil
 }
 
 func geocode(country string) (float64, float64, error) {

--- a/backend/pkg/geography/geocalc/service.go
+++ b/backend/pkg/geography/geocalc/service.go
@@ -2,26 +2,24 @@ package geocalc
 
 import "fmt"
 
-func GetDistance(guess string, answer string) (float64, error) {
-	distance, err := distanceMatrix(guess, answer)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get distance from Google Maps API: %w", err)
-	}
-
-	distanceKM := distance / 1000
-	return distanceKM, nil
-}
-
-func GetDirection(guess string, answer string) (string, error) {
+func GetDistanceAndDirection(guess string, answer string) (float64, string, error) {
 	guessLat, guessLng, err := geocode(guess)
 	if err != nil {
-		return "", fmt.Errorf("failed to geocode guess: %w", err)
+		return 0, "", fmt.Errorf("failed to geocode guess: %w", err)
 	}
 
 	answerLat, answerLng, err := geocode(answer)
 	if err != nil {
-		return "", fmt.Errorf("failed to geocode answer: %w", err)
+		return 0, "", fmt.Errorf("failed to geocode answer: %w", err)
 	}
 
-	return getCompass(guessLat, guessLng, answerLat, answerLng), nil
+	distance, err := haversine(guessLat, guessLng, answerLat, answerLng)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to calculate haversine distance: %w", err)
+	}
+
+	distanceKM := distance / 1000
+	direction := getCompass(guessLat, guessLng, answerLat, answerLng)
+
+	return distanceKM, direction, nil
 }

--- a/backend/pkg/geography/geocalc/service.go
+++ b/backend/pkg/geography/geocalc/service.go
@@ -1,0 +1,27 @@
+package geocalc
+
+import "fmt"
+
+func GetDistance(guess string, answer string) (float64, error) {
+	distance, err := distanceMatrix(guess, answer)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get distance from Google Maps API: %w", err)
+	}
+
+	distanceKM := distance / 1000
+	return distanceKM, nil
+}
+
+func GetDirection(guess string, answer string) (string, error) {
+	guessLat, guessLng, err := geocode(guess)
+	if err != nil {
+		return "", fmt.Errorf("failed to geocode guess: %w", err)
+	}
+
+	answerLat, answerLng, err := geocode(answer)
+	if err != nil {
+		return "", fmt.Errorf("failed to geocode answer: %w", err)
+	}
+
+	return getCompass(guessLat, guessLng, answerLat, answerLng), nil
+}


### PR DESCRIPTION
Exposing POST /api/guess endpoint. 
After the user guess a country through a POST request, our endpoint will provide a JSON with the following values: `direction`, `distance`, `isCorrect`.

**FYI**: 
- Narrow Ranges for Primary Directions: N, S, E, and W are given smaller ranges (e.g., ~11.25°).
- Wider Ranges for Intermediate Directions: Directions like NE, NW, etc., are given larger ranges (e.g., ~33.75°).
- Special Case for North: Since N wraps around 360°, it has a special condition to handle degrees near 0° and 360°.

**FYI**: When the guess is correct (`isCorrect: true`), the frontend should display a special indicator (like an emoji) instead of the direction.

**Tests**:
For Brazil as the answer:
![Imagem do WhatsApp de 2025-05-04 à(s) 18 57 52_84e16783](https://github.com/user-attachments/assets/9c2188c0-ae0b-40ae-8b70-0393b0615fac)
![Imagem do WhatsApp de 2025-05-04 à(s) 18 57 52_eea845e9](https://github.com/user-attachments/assets/8b5393a1-cf41-4c75-8232-1d16fec1cb7e)
![Imagem do WhatsApp de 2025-05-04 à(s) 18 57 52_ed10412c](https://github.com/user-attachments/assets/b5236e78-5fec-404a-899b-3420f79234ec)
![image](https://github.com/user-attachments/assets/a1f2cac8-d68c-4aad-a81b-128712870cd3)

Issue: https://github.com/MaarceloLuiz/worldle-replica/issues/9