### PR TITLE
feat: provide endpoint with the answer and url

### DIFF
--- a/backend/cmd/worldle/main.go
+++ b/backend/cmd/worldle/main.go
@@ -11,6 +11,7 @@ func main() {
 	http.HandleFunc("/api/newgame", corsMiddleware(api.NewGameHandler))
 	http.HandleFunc("/api/silhouette", corsMiddleware(api.SilhouetteHandler))
 	http.HandleFunc("/api/territories", corsMiddleware(api.AllTerritoriesHandler))
+	http.HandleFunc("/api/answer", corsMiddleware(api.AnswerHandler))
 	http.HandleFunc("/api/guess", corsMiddleware(api.GuessHandler))
 
 	logrus.Info("Starting server on :8080")

--- a/backend/pkg/api/handler.go
+++ b/backend/pkg/api/handler.go
@@ -50,6 +50,34 @@ func AllTerritoriesHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonData)
 }
 
+func AnswerHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message": "Use GET to retrieve the answer."}`))
+		return
+	}
+
+	answerCountry := game.State.Country
+	if answerCountry == "" {
+		http.Error(w, "Game not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	mapsURL, err := geocalc.GetMapsURLAnswer(answerCountry)
+	if err != nil {
+		http.Error(w, "Failed to generate maps URL for the answer", http.StatusInternalServerError)
+		return
+	}
+	response := map[string]string{
+		"answer": strings.ReplaceAll(strings.ToUpper(answerCountry), "_", " "),
+		"url":    mapsURL,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
 func GuessHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Content-Type", "application/json")

--- a/backend/pkg/geography/geocalc/service.go
+++ b/backend/pkg/geography/geocalc/service.go
@@ -2,6 +2,7 @@ package geocalc
 
 import (
 	"fmt"
+	"math"
 	"sync"
 )
 
@@ -27,6 +28,7 @@ func GetDistanceAndDirection(guess string, answer string) (float64, string, erro
 	}
 
 	distanceKM := distance / 1000
+	distanceKM = math.Round(distanceKM)
 	direction := getCompass(guessLat, guessLng, answerLat, answerLng)
 
 	return distanceKM, direction, nil

--- a/backend/pkg/geography/geocalc/service.go
+++ b/backend/pkg/geography/geocalc/service.go
@@ -49,6 +49,12 @@ func GetMapsURL(guess string, answer string) (string, error) {
 	return url, nil
 }
 
+func GetMapsURLAnswer(answer string) (string, error) {
+	url := fmt.Sprintf("https://www.google.com/maps/place/%s", answer)
+
+	return url, nil
+}
+
 func getCachedCoordinates(territory string) (float64, float64, error) {
 	cacheMutex.RLock()
 	coords, found := coordinatesCache[territory]


### PR DESCRIPTION
New endpoint available: `/api/answer`

It has the following structure:
```
{
  "answer": "BRAZIL",
  "url": "https://www.google.com/maps/place/brazil"
}
```